### PR TITLE
Update readme to reference 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To use Swiftly in your workflow, specify the repository followed by a tag as wit
 ```yaml
 steps:
   - uses: actions/checkout@v4
-  - uses: vapor/swiftly-action@v0.1
+  - uses: vapor/swiftly-action@v0.2.0
     with:
       toolchain: latest # optional
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To use Swiftly in your workflow, specify the repository followed by a tag as wit
 ```yaml
 steps:
   - uses: actions/checkout@v4
-  - uses: vapor/swiftly-action@v0.2.0
+  - uses: vapor/swiftly-action@v0.2
     with:
       toolchain: latest # optional
 ```


### PR DESCRIPTION
Readme just got a little stale. To use swiftly 1.0, the `0.2.0` tag has to be used.