### PR TITLE
Fix link to Swiftly in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # swiftly-action
 
-A GitHub Action for installing the [Swiftly toolchain manager for Swift](https://swift-server.github.io/swiftly/).
+A GitHub Action for installing the [Swiftly toolchain manager for Swift](https://www.swift.org/swiftly).
 
 ## Usage
 


### PR DESCRIPTION
Hello! Thanks for your work on this project. I'm excited to have something closer to a blessed path to installing Swift in GitHub Actions workflows.

Noticed that the link in the README was resolving with a 404, so here's a PR to https://www.swift.org/swiftly/, which seems to be the canonical URL for the project.