### PR TITLE
Add support for running action on macOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 on:
-  push: { branches: [ main ] }
+  push: { branches: [main] }
   pull_request: { types: [opened, reopened, synchronize, ready_for_review] }
 
 jobs:
@@ -52,12 +52,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        runner-os:
+          - ubuntu-latest
+          - macos-latest
         test-args:
           - '{}'
           - '{"toolchain":"latest"}'
           - '{"toolchain":"5.10"}'
           - '{"toolchain":"6.0"}'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner-os }}
     steps:
       - name: Test
         uses: vapor/swiftly-action@main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,12 @@ jobs:
     runs-on: ubuntu-latest
     container: ${{ matrix.base-image }}
     steps:
+      - name: Checkout action
+        uses: actions/checkout@v4
+        with:
+          path: ./swiftly-action
       - name: Test
-        uses: vapor/swiftly-action@main
+        uses: ./swiftly-action
         with: ${{ fromJSON(matrix.test-args) }}
   test-amznlinux2:
     strategy:
@@ -45,8 +49,12 @@ jobs:
     steps:
       - name: Add missing dependencies
         run: yum install -y git tar
+      - name: Checkout action
+        uses: actions/checkout@v4
+        with:
+          path: ./swiftly-action
       - name: Test
-        uses: vapor/swiftly-action@main
+        uses: ./swiftly-action
         with: ${{ fromJSON(matrix.test-args) }}
   test-barerunner:
     strategy:
@@ -62,6 +70,10 @@ jobs:
           - '{"toolchain":"6.0"}'
     runs-on: ${{ matrix.runner-os }}
     steps:
+      - name: Checkout action
+        uses: actions/checkout@v4
+        with:
+          path: ./swiftly-action
       - name: Test
-        uses: vapor/swiftly-action@main
+        uses: ./swiftly-action
         with: ${{ fromJSON(matrix.test-args) }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,12 +49,14 @@ jobs:
     steps:
       - name: Add missing dependencies
         run: yum install -y git tar
-      - name: Checkout action
-        uses: actions/checkout@v4
-        with:
-          path: ./swiftly-action
+      # FIXME: This doesn't work in the container, since amazonlinux:2 ships with a version of glibc that's too old for GitHub's Node20.
+      # - name: Checkout action
+      #   uses: actions/checkout@v4
+      #   with:
+      #     path: ./swiftly-action
       - name: Test
-        uses: ./swiftly-action
+        # uses: ./swiftly-action
+        uses: vapor/swiftly-action@main
         with: ${{ fromJSON(matrix.test-args) }}
   test-barerunner:
     strategy:

--- a/action.yml
+++ b/action.yml
@@ -65,16 +65,18 @@ runs:
           curl -O "https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz"
           tar zxf "swiftly-$(uname -m).tar.gz"
           SWIFTLY_BIN_PATH="$(pwd)/swiftly"
+          SWIFTLY_ENV_PATH="${HOME}/.local/share/swiftly/env.sh"
         elif [[ "${RUNNER_OS}" == 'macOS' ]]; then
           curl -O 'https://download.swift.org/swiftly/darwin/swiftly.pkg'
           installer -pkg swiftly.pkg -target CurrentUserHomeDirectory
-          SWIFTLY_BIN_PATH="${HOME}/local/bin/swiftly"
+          SWIFTLY_BIN_PATH="${HOME}/.swiftly/bin/swiftly" # The docs are incorrect (they mention ~/local/bin/swiftly)
+          SWIFTLY_ENV_PATH="${HOME}/.swiftly/env.sh"
         else
           echo "Unsupported OS: ${RUNNER_OS}"
           exit 1
         fi
         "${SWIFTLY_BIN_PATH}" init --assume-yes --no-modify-profile --skip-install --quiet-shell-followup
-        . "${HOME}/.local/share/swiftly/env.sh"
+        . "${SWIFTLY_ENV_PATH}"
         echo "SWIFTLY_HOME_DIR=${SWIFTLY_HOME_DIR}" >>"${GITHUB_ENV}"
         echo "SWIFTLY_BIN_DIR=${SWIFTLY_BIN_DIR}" >>"${GITHUB_ENV}"
         echo "${SWIFTLY_BIN_DIR}" >>"${GITHUB_PATH}"

--- a/action.yml
+++ b/action.yml
@@ -88,13 +88,14 @@ runs:
       env:
         REQUESTED_TOOLCHAIN: ${{ inputs.toolchain }}
       run: |
-        swiftly install --assume-yes --use --post-install-file "${HOME}/.swiftly-postinstall-cmds.sh" "${REQUESTED_TOOLCHAIN}"
-        if [[ -f "${HOME}/.swiftly-postinstall-cmds.sh" ]]; then
+        POST_INSTALL_FILE="${HOME}/.swiftly-postinstall-cmds.sh"
+        swiftly install --assume-yes --use --post-install-file "${POST_INSTALL_FILE}" "${REQUESTED_TOOLCHAIN}"
+        if [[ -f "${POST_INSTALL_FILE}" ]]; then
           export DEBIAN_FRONTEND=noninteractive # prevent Debian/Ubuntu installs from hanging on tzdata
           if [[ "$(id -un)" == 'root' ]]; then
-            . "${HOME}/.swiftly-postinstall-cmds.sh"
+            . "${POST_INSTALL_FILE}"
           else
-            sudo bash -c ". '${HOME}/.swiftly-postinstall-cmds.sh'" # use the current value of HOME rather than the subshell's value
+            sudo bash -c ". '${POST_INSTALL_FILE}'"
           fi
-          rm "${HOME}/.swiftly-postinstall-cmds.sh"
+          rm "${POST_INSTALL_FILE}"
         fi

--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,8 @@ runs:
             apt-get update -q && apt-get install -qy curl
           elif command -v yum >/dev/null; then
             yum install -y curl
+          elif command -v brew >/dev/null; then
+            brew install curl
           else
             echo "curl is not installed and we couldn't figure out how to install it."
             exit 1
@@ -45,6 +47,8 @@ runs:
             apt-get update -q && apt-get install -qy gpg
           elif command -v yum >/dev/null; then
             yum install -y gpg
+          elif command -v brew >/dev/null; then
+            brew install gpg
           else
             echo "gpg is not installed and we couldn't figure out how to install it."
             exit 1
@@ -54,19 +58,27 @@ runs:
     - id: swiftly-install
       name: Download and initialize Swiftly
       shell: bash
+      env:
+        RUNNER_OS: ${{ runner.os }}
       run: |
-        curl -O "https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz"
-        tar zxf "swiftly-$(uname -m).tar.gz"
-        ./swiftly init --assume-yes --no-modify-profile --skip-install --quiet-shell-followup
-        if [[ "$(id -un)" == 'root' ]]; then
-          . /root/.local/share/swiftly/env.sh
+        if [[ "${RUNNER_OS}" == 'Linux' ]]; then
+          curl -O "https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz"
+          tar zxf "swiftly-$(uname -m).tar.gz"
+          SWIFTLY_BIN_PATH="$(pwd)/swiftly"
+        elif [[ "${RUNNER_OS}" == 'macOS' ]]; then
+          curl -O 'https://download.swift.org/swiftly/darwin/swiftly.pkg'
+          installer -pkg swiftly.pkg -target CurrentUserHomeDirectory
+          SWIFTLY_BIN_PATH="${HOME}/local/bin/swiftly"
         else
-          . "/home/${USER}/.local/share/swiftly/env.sh"
+          echo "Unsupported OS: ${RUNNER_OS}"
+          exit 1
         fi
+        "${SWIFTLY_BIN_PATH}" init --assume-yes --no-modify-profile --skip-install --quiet-shell-followup
+        . "${HOME}/.local/share/swiftly/env.sh"
         echo "SWIFTLY_HOME_DIR=${SWIFTLY_HOME_DIR}" >>"${GITHUB_ENV}"
         echo "SWIFTLY_BIN_DIR=${SWIFTLY_BIN_DIR}" >>"${GITHUB_ENV}"
         echo "${SWIFTLY_BIN_DIR}" >>"${GITHUB_PATH}"
- 
+
     - id: toolchain-install
       name: Install requested Swift toolchain
       if: ${{ inputs.toolchain != '' }}

--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,14 @@ runs:
           curl -O "https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz"
           tar zxf "swiftly-$(uname -m).tar.gz"
           SWIFTLY_BIN_PATH="$(pwd)/swiftly"
-          SWIFTLY_ENV_PATH="${HOME}/.local/share/swiftly/env.sh"
+          if [[ "$(id -un)" == 'root' ]]; then
+            # There seems to be an issue when running the action inside a container where GitHub sets `HOME` on the container,
+            # but that change seems to be ignored by Swiftly.
+            SWIFTLY_ENV_BASE_PATH='/root'
+          else
+            SWIFTLY_ENV_BASE_PATH="${HOME}"
+          fi
+          SWIFTLY_ENV_PATH="${SWIFTLY_ENV_BASE_PATH}/.local/share/swiftly/env.sh"
         elif [[ "${RUNNER_OS}" == 'macOS' ]]; then
           curl -O 'https://download.swift.org/swiftly/darwin/swiftly.pkg'
           installer -pkg swiftly.pkg -target CurrentUserHomeDirectory


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->

Currently, running the action on macOS runners fails (the tar.gz is not found). Installing swiftly on macOS uses a pkg installer (see https://www.swift.org/install/macos/).
This is also mentioned in [the "Installing Swiftly Automatically" docs](https://www.swift.org/swiftly/documentation/swiftly/automated-install).
I've adjusted the action to use the pkg installer on macOS (including running the baserunner tests on macOS), as well as using brew for installing any missing dependencies.